### PR TITLE
mido: fpc_mido: maintain compatibility sysfs symbolic link

### DIFF
--- a/drivers/input/fingerprint/fpc_mido/fpc1020_tee.c
+++ b/drivers/input/fingerprint/fpc_mido/fpc1020_tee.c
@@ -88,6 +88,10 @@ static int fpc1020_request_named_gpio(struct fpc1020_data *fpc1020,
 		const char *label, int *gpio);
 static int hw_reset(struct  fpc1020_data *fpc1020);
 
+#ifdef CONFIG_MACH_XIAOMI_MIDO
+static struct kernfs_node *soc_symlink = NULL;
+#endif
+
 #ifdef LINUX_CONTROL_SPI_CLK
 static int set_clks(struct fpc1020_data *fpc1020, bool enable)
 {
@@ -490,6 +494,11 @@ static int fpc1020_probe(struct platform_device *pdev)
 {
 	struct device *dev = &pdev->dev;
 	int rc = 0;
+#ifdef CONFIG_MACH_XIAOMI_MIDO
+	struct device *platform_dev;
+	struct kobject *soc_kobj;
+	struct kernfs_node *devices_node, *soc_node;
+#endif
 
 	struct device_node *np = dev->of_node;
 
@@ -549,6 +558,30 @@ static int fpc1020_probe(struct platform_device *pdev)
 		goto exit;
 	}
 
+#ifdef CONFIG_MACH_XIAOMI_MIDO
+	if(!dev->parent || !dev->parent->parent) {
+		dev_warn(dev, "Parent platform device not found");
+		goto exit;
+	}
+
+	platform_dev = dev->parent->parent;
+	if(strcmp(kobject_name(&platform_dev->kobj), "platform")) {
+		dev_warn(dev, "Parent platform device name not matched: %s", kobject_name(&platform_dev->kobj));
+		goto exit;
+	}
+
+	devices_node = platform_dev->kobj.sd->parent;
+	soc_kobj = &dev->parent->kobj;
+	soc_node = soc_kobj->sd;
+	kernfs_get(soc_node);
+
+	soc_symlink = kernfs_create_link(devices_node, kobject_name(soc_kobj), soc_node);
+	kernfs_put(soc_node);
+	if(IS_ERR(soc_symlink)) {
+		dev_warn(dev, "Unable to create soc symlink");
+	}
+#endif
+
 	dev_info(dev, "%s: ok\n", __func__);
 exit:
 	return rc;
@@ -556,6 +589,12 @@ exit:
 
 static int fpc1020_remove(struct platform_device *pdev)
 {
+#ifdef CONFIG_MACH_XIAOMI_MIDO
+	if(!IS_ERR(soc_symlink)) {
+		kernfs_remove_by_name(soc_symlink->parent, soc_symlink->name);
+	}
+#endif
+
 	struct  fpc1020_data *fpc1020 = dev_get_drvdata(&pdev->dev);
 
 	sysfs_remove_group(&pdev->dev.kobj, &attribute_group);


### PR DESCRIPTION
Using 3.18 kernel fpc sysfs path was /sys/devices/soc/soc:fpc1020,
however in 4.9 it is now in /sys/devices/platform/soc/soc:fpc1020.
This is a problem for proprietary userland, which is hard to change, so
let's maintain compatibility soc symlink for mido.

See-Also: https://github.com/nE0sIghT/android_kernel_xiaomi_msm8953/issues/18